### PR TITLE
[Fix] calendar 달성률 조회 api 호출조건 수정

### DIFF
--- a/src/components/panels/UserPanel.tsx
+++ b/src/components/panels/UserPanel.tsx
@@ -2,24 +2,13 @@
 import React from 'react';
 import UserGreeting from '@/components/user/UserGreeting';
 import UserCalendar from '@/components/user/UserCalendar';
-const exampleData = {
-  '2025-05-01': 100,
-  '2025-05-02': 60,
-  '2025-05-03': 30,
-  '2025-05-04': 90,
-  '2025-05-95': 50,
-  '2025-05-08': 20,
-  '2025-05-09': 20,
-  '2025-05-11': 20,
-  '2025-05-12': 20,
-  '2025-05-15': 20,
-};
+
 const UserPanel: React.FC = () => {
   return (
     <div className="space-y-4">
       <UserGreeting />
 
-      <UserCalendar percentageMap={exampleData} />
+      <UserCalendar />
     </div>
   );
 };

--- a/src/components/user/UserCalendar.tsx
+++ b/src/components/user/UserCalendar.tsx
@@ -47,7 +47,7 @@ const StyledCalendar = styled(Calendar)`
   }
 
   .react-calendar__tile:hover {
-    background-color: transparent;
+    background-color: transparent !important;
   }
 
   .react-calendar__tile:hover::before {
@@ -60,6 +60,19 @@ const StyledCalendar = styled(Calendar)`
     border-radius: 50%;
     z-index: 0;
   }
+
+  /* 타일 안의 날짜 글씨 기본 */
+  .react-calendar__tile {
+    color: #333;
+  }
+  /* 날짜 뷰에서만 적용되도록 .react-calendar__month-view 추가 */
+  .react-calendar__month-view .react-calendar__tile.sunday abbr {
+    color: red;
+  }
+
+  .react-calendar__month-view .react-calendar__tile.saturday abbr {
+    color: blue;
+  }
 `;
 
 const UserCalendar = () => {
@@ -70,11 +83,8 @@ const UserCalendar = () => {
       console.log('🔴 UserCalendar unmounted');
     };
   }, []);
+
   const [selectedDate, setSelectedDate] = useState(new Date());
-  const [percentageMap, setPercentageMap] = useState<Record<string, number>>(
-    {},
-  );
-  const [selectedKey, setSelectedKey] = useState<string>(''); // 선택된 날짜 키
 
   // 날짜를 "YYYY-MM-DD" 형식으로 변환
   // useCallback 사용하여 불필요한 함수 재생성을 방지
@@ -84,6 +94,15 @@ const UserCalendar = () => {
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
   }, []);
+
+  // selectedDate 기준으로 selectedKey 초기값 설정
+  const [selectedKey, setSelectedKey] = useState(() =>
+    formatDateKey(new Date()),
+  );
+  const [percentageMap, setPercentageMap] = useState<Record<string, number>>(
+    {},
+  );
+  const [prevYearMonth, setPrevYearMonth] = useState(''); //  이전 연-월 저장하고 변경시에만 달성률 조회
 
   const fetchCalendarData = async (yearMonthStr: string) => {
     try {
@@ -113,8 +132,13 @@ const UserCalendar = () => {
     const year = selectedDate.getFullYear();
     const month = String(selectedDate.getMonth() + 1).padStart(2, '0');
     const yearMonthStr = `${year}-${month}`;
-    fetchCalendarData(yearMonthStr);
-  }, [selectedDate]); // 의존성 배열에 `selectedDate`만 포함
+
+    // 이전 연-월과 다를 때만 fetch
+    if (yearMonthStr !== prevYearMonth) {
+      fetchCalendarData(yearMonthStr);
+      setPrevYearMonth(yearMonthStr); // 요청 후 이전 연-월 갱신
+    }
+  }, [selectedDate]); // selectedDate 변경 시 호출
 
   const handleActiveStartDateChange = ({ activeStartDate, view }) => {
     if (view === 'month' && activeStartDate) {
@@ -147,6 +171,12 @@ const UserCalendar = () => {
         locale="en-US"
         next2Label={null}
         prev2Label={null}
+        tileClassName={({ date }) => {
+          const day = date.getDay(); // 0: 일요일, 6: 토요일
+          if (day === 0) return 'sunday';
+          if (day === 6) return 'saturday';
+          return null;
+        }}
         tileContent={({ date }) => {
           const key = formatDateKey(date);
           const percent = percentageMap[key];


### PR DESCRIPTION
## #️⃣연관된 이슈
해당 년월 달성률 조회하는 /calendar를 호출하는 조건 수정

## 📝작업 내용

- 같은 달의 일자 클릭 시 호출 x
- 해당 달에 있는 지난달/다음달 일자 클릭 시 호출 o
- 상단 월 변경 버튼 클릭해서 달 변경 시 호출 o

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> _리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요_<br>
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
